### PR TITLE
Fix typo in state.md

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -6,7 +6,7 @@ UIx is using [React's state hook](https://reactjs.org/docs/hooks-state.html#hook
 (defui form []
   (let [[value set-value!] (uix.core/use-state "")]
     ($ :input {:value value
-               :on-change #(set-value! value (.. % -target -value))})))
+               :on-change #(set-value! (.. % -target -value))})))
 ```
 
 In some React wrappers state is represented using the `Atom` datatype that has has `reset!` and `swap!` operations. We take a similar naming approach and suffix state updating function with a bang `!` denoting that the operation is mutating a value.


### PR DESCRIPTION
Started to use uix and this confused me quite a bit.
Coming from reagent and in general a different stack, i just copy pasted this and needed some time to figure out it is a typo.
